### PR TITLE
302841 - [Footer] Accessibility  statement content

### DIFF
--- a/__tests__/controllers/web/HomeController.spec.ts
+++ b/__tests__/controllers/web/HomeController.spec.ts
@@ -125,4 +125,14 @@ describe('Deals with Home Controller', () => {
       );
     });
   });
+  describe('Deals with the accessibilityHandler', () => {
+    it('should call the accessibility view with context', async () => {
+      const request: Request = {} as any;
+      const response: ResponseToolkit = { view: jest.fn() } as any;
+      await HomeController.accessibilityHandler(request, response);
+      expect(response.view).toHaveBeenCalledWith('screens/home/accessibility', {
+        pageTitle: pageTitles.accessibility,
+      });
+    });
+  });
 });

--- a/__tests__/infrastructure/plugins/views.spec.ts
+++ b/__tests__/infrastructure/plugins/views.spec.ts
@@ -14,6 +14,7 @@ const {
   getMapFilters,
   filterResourceType,
   filterStudyPeriod,
+  accessibilityStatement,
 } = webRoutePaths;
 
 describe('Vision Plugin Configuration', () => {
@@ -61,6 +62,7 @@ describe('Vision Plugin Configuration', () => {
         getMapFilters,
         filterResourceType,
         filterStudyPeriod,
+        accessibilityStatement,
       },
       appInsightsConnectionString:
         environmentConfig.appInsightsConnectionString,

--- a/__tests__/routes/web/__snapshots__/404.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/404.spec.ts.snap
@@ -187,8 +187,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
                 </li>
               
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#">
+                  <a class="govuk-footer__link" href="/accessibility-statement">
                     Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="#">
+                    Terms and conditions
                   </a>
                 </li>
               

--- a/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elements on the page with guided search POST validation Sanpshot verification & status code should match the results screen snapshot 1`] = `
+exports[`Accessibility Screen Accessibility > Sanpshot verification should match the accessibility screen snapshot 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template app-html-class">
   <head>
     <meta charset="utf-8">
     <title>
-  NCEA Guided Search - Geographic Data
+  Accessibility statement
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -22,13 +22,10 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
 
 
     
-  
   <link rel="stylesheet" href="/assets/css/application.css">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-
-  <link rel="stylesheet" href="/assets/css/ol.css">
 
     
   </head>
@@ -134,179 +131,52 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
 </div>
 
 
+  <div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+
+  
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/" data-do-storage-reset="">Home</a>
+    </li>
   
 
-<a href="/date-search" class="govuk-back-link">Back</a>
+  
+    <li class="govuk-breadcrumbs__list-item" aria-current="page">Accessibility statement</li>
+  
+
+  </ol>
+</div>
 
 
         <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
           
-  <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    
-    <div class="govuk-section-break--visible"></div>
-  </div>
-</div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full govuk-!-padding-top-6 govuk-!-padding-bottom-6">
-      <h2 class="govuk-heading-l">What geography does it cover?</h2>
-      <h1 class="govuk-heading-m">Draw area on map</h1>
-      <span class="govuk-caption-m">Click and drag to draw a boundary box. This will auto-populate the geographical coordinate box.</span>
-    </div>
-  </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <div id="coordinate-map" style="width: 660px; height: 623px;"></div>
-    </div>
-  </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full govuk-!-padding-top-6 govuk-!-padding-bottom-6">
-      <h1 class="govuk-heading-m">Geographical coordinate box</h1>
-      <span class="govuk-caption-m">Enter a coordinate in each field to create a geographic bounding box. This will show you the data that exists within that geographical area.</span>
-    </div>
-  </div>
-  <form method="POST" action="/coordinate-search?" id="extent" data-do-browser-storage data-toggle-submit-button>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
-        <div class="geography-fields__container">
-          <div class="geography-fields__field">
-
-<div class="govuk-form-group govuk-!-margin-0">
-  <label class="govuk-label" for="north">
-    North
-  </label>
-
-  
-  
-  <div id="north-hint" class="govuk-hint">
-    For example, -4.351
-  </div>
-
-
-  <input class="govuk-input" id="north" name="north" type="text" value="2" aria-describedby="north-hint" altName="nth">
-
-</div>
-</div>
-          <div class="geography-fields__field">
-
-<div class="govuk-form-group govuk-!-margin-0">
-  <label class="govuk-label" for="south">
-    South
-  </label>
-
-  
-  
-  <div id="south-hint" class="govuk-hint">
-    For example, -4.351
-  </div>
-
-
-  <input class="govuk-input" id="south" name="south" type="text" value="2" aria-describedby="south-hint" altName="sth">
-
-</div>
-</div>
-          <div class="geography-fields__field">
-
-<div class="govuk-form-group govuk-!-margin-0">
-  <label class="govuk-label" for="east">
-    East
-  </label>
-
-  
-  
-  <div id="east-hint" class="govuk-hint">
-    For example, -4.351
-  </div>
-
-
-  <input class="govuk-input" id="east" name="east" type="text" value="2" aria-describedby="east-hint" altName="est">
-
-</div>
-</div>
-          <div class="geography-fields__field">
-
-<div class="govuk-form-group govuk-form-group--error govuk-!-margin-0">
-  <label class="govuk-label" for="west">
-    West
-  </label>
-
-  
-  
-  <div id="west-hint" class="govuk-hint">
-    For example, -4.351
-  </div>
-
-
-  
-  
-  <p id="west-error" class="govuk-error-message">
-    
-    <span class="govuk-visually-hidden">Error:</span> You must enter all four coordinates.
-    
-  </p>
-
-  <input class="govuk-input govuk-input--error govuk-input--error" id="west" name="west" type="text" aria-describedby="west-hint west-error" altName="wst">
-
-</div>
-</div>
-          <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-3 defra-map-clear-selection__block" id="clear-map-selection">
-            <a href="javascript:void(0);" class="govuk-link defra-map-clear-selection__link">
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="17" class="govuk-!-margin-right-1" viewBox="0 0 16 17" fill="none">
-                <g clip-path="url(#clip0_7099_112575)">
-                  <path d="M12.6673 5.02594L11.7273 4.08594L8.00065 7.8126L4.27398 4.08594L3.33398 5.02594L7.06065 8.7526L3.33398 12.4793L4.27398 13.4193L8.00065 9.6926L11.7273 13.4193L12.6673 12.4793L8.94065 8.7526L12.6673 5.02594Z" fill="#1D70B8"/>
-                </g>
-                <defs>
-                  <clipPath id="clip0_7099_112575">
-                    <rect width="16" height="16" fill="white" transform="translate(0 0.75)"/>
-                  </clipPath>
-                </defs>
-              </svg>
-              <span>Clear selection</span>
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="govuk-grid-row  govuk-!-margin-top-4 govuk-!-margin-bottom-6 geography-buttons">
-      <div class="govuk-grid-column-one-half geography-buttons__left">
-        
-  
-
-  
-    
-  
-
-<a href="/date-search" role="button" draggable="false" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button">
-  Previous question
-</a>
-
-      </div>
-      <div class="govuk-grid-column-one-half govuk-button-group govuk-!-margin-bottom-0 geography-buttons__right">
-        
-  
-
-  
-    
-  
-
-<a href="/search?" role="button" draggable="false" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" data-do-storage-skip="">
-  Skip question
-</a>
-
-        
-  
-
-  
-    
-  
-
-<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-0" data-module="govuk-button" data-to-disable="" data-next-question="">
-  Show results
-</button>
-
-      </div>
-    </div>
-  </form>
+  <article class="govuk-grid-row" role="article">
+    <article class="govuk-grid-column-full ncea-static-page">
+      <h1 class="govuk-heading-m ncea-static-page__heading-m">Accessibility statement</h1>
+      <section class="ncea-static-page__content">
+        <p class="ncea-static-page__content-item">This accessibility statement applies to the Natural Capital Search Service.</p>
+        <p class="ncea-static-page__content-item">This service is run by the NCEA programme, on behalf of the Department for Environment, Food and Rural Affairs (Defra).</p>
+        <p class="ncea-static-page__content-item">We want as many people as possible to be able to use this website. It has been designed using GDS components and patterns, which are accessible. We've also made the website text as simple as possible to understand.</p>
+      </section>
+      <h2 class="govuk-heading-s ncea-static-page__heading-s govuk-!-margin-top-4">What we're doing to improve accessibility</h2>
+      <section class="ncea-static-page__content">
+        <p class="ncea-static-page__content-item">This service is currently in private beta. It does not yet fully meet <a href="https://www.w3.org/WAI/standards-guidelines/wcag/" class="govuk-link" target="_blank">Web Content Accessibility Guidelines</a> version 2.2 AA standard.</p>
+        <p class="ncea-static-page__content-item">An accessibility audit will take place during private beta. After the audit, we will work alongside other government departments and agencies to fix content which fails to meet the Web Content Accessibility Guidelines version 2.2 AA standard.</p>
+        <p class="ncea-static-page__content-item">An updated accessibility statement will be published after this date.</p>
+      </section>
+      <h2 class="govuk-heading-s ncea-static-page__heading-s govuk-!-margin-top-4">Feedback and contact information</h2>
+      <section class="ncea-static-page__content">
+        <p class="ncea-static-page__content-item">
+          If you would like to give feedback or report accessibility problems with this service, email us at <a class="govuk-link" href="mailto:NCEAemail@email.com">NCEAemail@email.com.</a>
+        </p>
+      </section>
+      <h2 class="govuk-heading-s ncea-static-page__heading-s govuk-!-margin-top-4">Preparation of this accessibility statement</h2>
+      <section class="ncea-static-page__content govuk-!-margin-bottom-8">
+        <p class="ncea-static-page__content-item">This statement was prepared on 26 April 2024.</p>
+        <p class="ncea-static-page__content-item">Last updated 29 April 2024.</p>
+      </section>
+    </article>
+  </article>
 
         </main>
       </div>
@@ -398,7 +268,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
 
     
   
-  
   <script type="module" src="/assets/all.js"></script>
   <script type="module">
     import {initAll} from '/assets/all.js'
@@ -409,9 +278,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
   </script>
   <script type="text/javascript" src="/assets/scripts/appinsights.js"></script>
   <script type="module" src="/assets/scripts/customScripts.js"></script>
-
-  <script src="/assets/scripts/ol.js"></script>
-  <script type="module" src="/assets/scripts/location.js"></script>
 
   </body>
 </html>

--- a/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
@@ -391,8 +391,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
                 </li>
               
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#">
+                  <a class="govuk-footer__link" href="/accessibility-statement">
                     Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="#">
+                    Terms and conditions
                   </a>
                 </li>
               

--- a/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
@@ -206,11 +206,16 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
   
 
   
+
+  
     
   
 
-<button type="submit" class="govuk-button govuk-!-margin-bottom-4" data-module="govuk-button" onclick="openDataModal(&#39;United Kingdom Hydrographic Office&#39;, &#39;https://seabed.admiralty.co.uk&#39;)">
+<button type="submit" class="govuk-button govuk-!-margin-bottom-4  govuk-button--start" data-module="govuk-button" onclick="openDataModal(&#39;United Kingdom Hydrographic Office&#39;, &#39;https://seabed.admiralty.co.uk&#39;)">
   Go to resource
+  <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+    <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
+  </svg>
 </button>
 
       
@@ -894,8 +899,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
                 </li>
               
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#">
+                  <a class="govuk-footer__link" href="/accessibility-statement">
                     Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="#">
+                    Terms and conditions
                   </a>
                 </li>
               
@@ -1168,11 +1179,16 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
   
 
   
+
+  
     
   
 
-<button type="submit" class="govuk-button govuk-!-margin-bottom-4" data-module="govuk-button" disabled="true">
+<button type="submit" class="govuk-button govuk-!-margin-bottom-4  govuk-button--start" data-module="govuk-button" disabled="true">
   Go to resource
+  <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+    <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
+  </svg>
 </button>
 
       
@@ -1825,8 +1841,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
                 </li>
               
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#">
+                  <a class="govuk-footer__link" href="/accessibility-statement">
                     Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="#">
+                    Terms and conditions
                   </a>
                 </li>
               

--- a/__tests__/routes/web/__snapshots__/geographySearchGet.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchGet.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
   <head>
     <meta charset="utf-8">
     <title>
-  NCEA Guided Search -Geographic Data
+  NCEA Guided Search - Geographic Data
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -335,8 +335,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
                 </li>
               
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#">
+                  <a class="govuk-footer__link" href="/accessibility-statement">
                     Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="#">
+                    Terms and conditions
                   </a>
                 </li>
               

--- a/__tests__/routes/web/__snapshots__/home.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/home.spec.ts.snap
@@ -267,8 +267,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
                 </li>
               
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#">
+                  <a class="govuk-footer__link" href="/accessibility-statement">
                     Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="#">
+                    Terms and conditions
                   </a>
                 </li>
               

--- a/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
@@ -517,8 +517,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
                 </li>
               
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#">
+                  <a class="govuk-footer__link" href="/accessibility-statement">
                     Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="#">
+                    Terms and conditions
                   </a>
                 </li>
               
@@ -1008,8 +1014,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
                 </li>
               
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#">
+                  <a class="govuk-footer__link" href="/accessibility-statement">
                     Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="#">
+                    Terms and conditions
                   </a>
                 </li>
               
@@ -1726,8 +1738,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
                 </li>
               
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#">
+                  <a class="govuk-footer__link" href="/accessibility-statement">
                     Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="#">
+                    Terms and conditions
                   </a>
                 </li>
               
@@ -2293,8 +2311,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
                 </li>
               
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#">
+                  <a class="govuk-footer__link" href="/accessibility-statement">
                     Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="#">
+                    Terms and conditions
                   </a>
                 </li>
               
@@ -2784,8 +2808,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
                 </li>
               
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#">
+                  <a class="govuk-footer__link" href="/accessibility-statement">
                     Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="#">
+                    Terms and conditions
                   </a>
                 </li>
               

--- a/__tests__/routes/web/accessibility.spec.ts
+++ b/__tests__/routes/web/accessibility.spec.ts
@@ -1,0 +1,240 @@
+/**
+ * @jest-environment jsdom
+ */
+
+'use strict';
+
+import { Server } from '@hapi/hapi';
+
+import { initializeServer } from '../../../src/infrastructure/server';
+import supertest from 'supertest';
+import { webRoutePaths } from '../../../src/utils/constants';
+
+jest.mock('../../../src/infrastructure/plugins/appinsights-logger', () => ({
+  info: jest.fn(),
+}));
+
+jest.mock('../../../src/utils/keyvault', () => ({
+  getSecret: jest.fn(),
+}));
+
+let serverRequest;
+
+const invokeRoute = async (route) => {
+  const response = await serverRequest.get(route);
+  const rawHTML = response.text;
+  const parser = new DOMParser();
+  const document = parser.parseFromString(rawHTML, 'text/html');
+  return { response, document };
+};
+
+describe('Accessibility Screen', () => {
+  let server: Server;
+  let response;
+  let document: Document;
+
+  beforeAll((done) => {
+    initializeServer().then(async (s: Server) => {
+      server = s;
+      serverRequest = supertest(server.listener);
+
+      const responseObject = await invokeRoute(
+        webRoutePaths.accessibilityStatement,
+      );
+      response = responseObject.response;
+      document = responseObject.document;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    server.stop().then(() => done());
+  });
+
+  describe('Accessibility > Sanpshot verification', () => {
+    it('should match the accessibility screen snapshot', async () => {
+      expect(response?.text).toMatchSnapshot();
+    });
+  });
+
+  describe('Accessibility > Check accessibility route status code', () => {
+    it('should / route works with status code 200', async () => {
+      expect(response.statusCode).toEqual(200);
+    });
+  });
+
+  describe('Breadcrumb classes', () => {
+    it('renders the container class', async () => {
+      expect(document.querySelector('.govuk-breadcrumbs')).toBeTruthy();
+    });
+
+    it('renders the breadcrumb list class', async () => {
+      expect(document.querySelector('.govuk-breadcrumbs__list')).toBeTruthy();
+    });
+  });
+
+  describe('Breadcrumb list items', () => {
+    it('should render 2 list items', async () => {
+      const breadcrumbList = document?.querySelector(
+        '.govuk-breadcrumbs__list',
+      );
+      expect(breadcrumbList?.childElementCount).toEqual(2);
+    });
+  });
+
+  describe('Breadcrumb list item options', () => {
+    it('should render home list item first child as an anchor tag', async () => {
+      const breadcrumbItems = document?.querySelector(
+        '.govuk-breadcrumbs__list',
+      )?.children;
+      const anchor = breadcrumbItems?.[0]?.firstElementChild;
+      expect(anchor?.tagName.toLowerCase()).toBe('a');
+      expect(anchor?.getAttribute('class')).toEqual('govuk-breadcrumbs__link');
+      expect(anchor?.getAttribute('href')).toEqual(webRoutePaths.home);
+      expect(anchor?.textContent?.trim()).toEqual('Home');
+    });
+
+    it('should not render accessibility statement list item second child not as an anchor', async () => {
+      const item = document.querySelector(
+        '.govuk-breadcrumbs__list',
+      )?.lastElementChild;
+      expect(item?.querySelector('a')).toBeNull();
+      expect(item?.textContent?.trim()).toEqual('Accessibility statement');
+    });
+  });
+
+  describe('Content section 1', () => {
+    it('should render the heading Accessibility statement', async () => {
+      const heading = document.querySelector('.ncea-static-page__heading-m');
+      expect(heading?.textContent?.trim()).toEqual('Accessibility statement');
+    });
+    it('should render 3 items', async () => {
+      const contentSections = document.querySelectorAll(
+        '.ncea-static-page__content',
+      );
+      const content = contentSections?.[0];
+      expect(content?.childElementCount).toBe(3);
+    });
+    it('should render 3 items content', async () => {
+      const contentSections = document.querySelectorAll(
+        '.ncea-static-page__content',
+      );
+      const content = contentSections?.[0];
+      const items = content?.querySelectorAll(
+        'p.ncea-static-page__content-item',
+      );
+      expect(items?.[0]?.textContent?.trim()).toEqual(
+        'This accessibility statement applies to the Natural Capital Search Service.',
+      );
+      expect(items?.[1]?.textContent?.trim()).toEqual(
+        'This service is run by the NCEA programme, on behalf of the Department for Environment, Food and Rural Affairs (Defra).',
+      );
+      expect(items?.[2]?.textContent?.trim()).toEqual(
+        "We want as many people as possible to be able to use this website. It has been designed using GDS components and patterns, which are accessible. We've also made the website text as simple as possible to understand.",
+      );
+    });
+  });
+
+  describe('Content section 2', () => {
+    it('should render the heading', async () => {
+      const headings = document.querySelectorAll(
+        '.ncea-static-page__heading-s',
+      );
+      const heading = headings[0];
+      expect(heading?.textContent?.trim()).toEqual(
+        "What we're doing to improve accessibility",
+      );
+    });
+    it('should render 3 items', async () => {
+      const contentSections = document.querySelectorAll(
+        '.ncea-static-page__content',
+      );
+      const content = contentSections?.[1];
+      expect(content?.childElementCount).toBe(3);
+    });
+    it('should render 3 items content', async () => {
+      const contentSections = document.querySelectorAll(
+        '.ncea-static-page__content',
+      );
+      const content = contentSections?.[1];
+      const items = content?.querySelectorAll(
+        'p.ncea-static-page__content-item',
+      );
+      console.log(items?.[0]?.textContent);
+      expect(items?.[0]?.textContent?.trim()).toEqual(
+        'This service is currently in private beta. It does not yet fully meet Web Content Accessibility Guidelines version 2.2 AA standard.',
+      );
+      expect(items?.[1]?.textContent?.trim()).toEqual(
+        'An accessibility audit will take place during private beta. After the audit, we will work alongside other government departments and agencies to fix content which fails to meet the Web Content Accessibility Guidelines version 2.2 AA standard.',
+      );
+      expect(items?.[2]?.textContent?.trim()).toEqual(
+        'An updated accessibility statement will be published after this date.',
+      );
+    });
+  });
+
+  describe('Content section 3', () => {
+    it('should render the heading', async () => {
+      const headings = document.querySelectorAll(
+        '.ncea-static-page__heading-s',
+      );
+      const heading = headings[1];
+      expect(heading?.textContent?.trim()).toEqual(
+        'Feedback and contact information',
+      );
+    });
+    it('should render 1 item', async () => {
+      const contentSections = document.querySelectorAll(
+        '.ncea-static-page__content',
+      );
+      const content = contentSections?.[2];
+      expect(content?.childElementCount).toBe(1);
+    });
+    it('should render 1 item content', async () => {
+      const contentSections = document.querySelectorAll(
+        '.ncea-static-page__content',
+      );
+      const content = contentSections?.[2];
+      const items = content?.querySelectorAll(
+        'p.ncea-static-page__content-item',
+      );
+      expect(items?.[0]?.textContent?.trim()).toEqual(
+        'If you would like to give feedback or report accessibility problems with this service, email us at NCEAemail@email.com.',
+      );
+    });
+  });
+
+  describe('Content section 4', () => {
+    it('should render the heading', async () => {
+      const headings = document.querySelectorAll(
+        '.ncea-static-page__heading-s',
+      );
+      const heading = headings[2];
+      expect(heading?.textContent?.trim()).toEqual(
+        'Preparation of this accessibility statement',
+      );
+    });
+    it('should render 1 item', async () => {
+      const contentSections = document.querySelectorAll(
+        '.ncea-static-page__content',
+      );
+      const content = contentSections?.[3];
+      expect(content?.childElementCount).toBe(2);
+    });
+    it('should render 1 item content', async () => {
+      const contentSections = document.querySelectorAll(
+        '.ncea-static-page__content',
+      );
+      const content = contentSections?.[3];
+      const items = content?.querySelectorAll(
+        'p.ncea-static-page__content-item',
+      );
+      expect(items?.[0]?.textContent?.trim()).toEqual(
+        'This statement was prepared on 26 April 2024.',
+      );
+      expect(items?.[1]?.textContent?.trim()).toEqual(
+        'Last updated 29 April 2024.',
+      );
+    });
+  });
+});

--- a/public/css/application.css
+++ b/public/css/application.css
@@ -7647,6 +7647,36 @@
   border-top: 1.5px solid #b1b4b6;
 }
 
+.ncea-static-page__heading-m {
+  font-size: 3rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 50px;
+  color: #0b0c0c;
+}
+.ncea-static-page__heading-s {
+  font-size: 1.5rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 30px;
+  color: #0b0c0c;
+}
+.ncea-static-page__content {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-auto-rows: minmax(auto, max-content);
+  row-gap: 20px;
+}
+.ncea-static-page__content-item {
+  font-family: "GDS Transport", arial, sans-serif;
+  font-size: 1.1875rem;
+  font-style: normal;
+  font-weight: 300;
+  line-height: 25px;
+  color: #0b0c0c;
+  margin: 0;
+}
+
 @media only screen and (min-width: 769px) {
   .header-container {
     display: block;

--- a/src/assets/sass/templates/_home.scss
+++ b/src/assets/sass/templates/_home.scss
@@ -12,16 +12,16 @@
 
   &__heading-xl {
     @include font-style-stack(36px, 40px);
-    color: govuk-colour('white');
+    color: govuk-colour("white");
     margin-bottom: 20px;
   }
 
   &__caption-l {
     @include font-style-stack(19px, 30px, 300);
-    color: govuk-colour('white');
+    color: govuk-colour("white");
   }
 
-  &__ncea-logo{
+  &__ncea-logo {
     height: 88px;
     gap: 0px;
     opacity: 0px;
@@ -38,5 +38,29 @@
     padding-bottom: 30px;
     margin: 0px;
     border-top: 1.5px solid $govuk-border-colour;
+  }
+}
+
+.ncea-static-page {
+  &__heading-m {
+    @include font-style-stack(48px, 50px, 700);
+    color: $govuk-text-colour;
+  }
+  &__heading-s {
+    @include font-style-stack(24px, 30px, 700);
+    color: $govuk-text-colour;
+  }
+
+  &__content {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-auto-rows: minmax(auto, max-content);
+    row-gap: 20px;
+
+    &-item {
+      @include font-style-stack(19px, 25px, 300, normal, true);
+      color: $govuk-text-colour;
+      margin: 0;
+    }
   }
 }

--- a/src/controllers/web/HomeController.ts
+++ b/src/controllers/web/HomeController.ts
@@ -62,6 +62,11 @@ const HomeController = {
     }
     return response.redirect(webRoutePaths.home);
   },
+  accessibilityHandler: (request: Request, response: ResponseToolkit): ResponseObject => {
+    return response.view('screens/home/accessibility', {
+      pageTitle: pageTitles.accessibility,
+    });
+  },
 };
 
 export { HomeController };

--- a/src/infrastructure/plugins/views.ts
+++ b/src/infrastructure/plugins/views.ts
@@ -13,6 +13,7 @@ const {
   getMapFilters,
   filterResourceType,
   filterStudyPeriod,
+  accessibilityStatement,
 } = webRoutePaths;
 
 const customHapiViews = {
@@ -68,6 +69,7 @@ const customHapiViews = {
         getMapFilters,
         filterResourceType,
         filterStudyPeriod,
+        accessibilityStatement,
       },
       appInsightsConnectionString: environmentConfig.appInsightsConnectionString,
       gtmId: environmentConfig.gtmId,

--- a/src/routes/web/home.ts
+++ b/src/routes/web/home.ts
@@ -15,6 +15,11 @@ const homeRoutes = [
     path: `${webRoutePaths.intermediate}/{step}`,
     handler: HomeController.intermediateHandler,
   },
+  {
+    method: 'GET',
+    path: webRoutePaths.accessibilityStatement,
+    handler: HomeController.accessibilityHandler,
+  },
 ];
 
 export { homeRoutes };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -12,6 +12,7 @@ export const webRoutePaths = {
   filterResourceType: '/resource-type-filter',
   filterStudyPeriod: '/study-period-filter',
   sortResults: '/sort-results',
+  accessibilityStatement: '/accessibility-statement',
 };
 
 export const elasticSearchAPIPaths = {
@@ -261,7 +262,7 @@ export const detailsTabOptions: TabOptions = {
 export const pageTitles = {
   home: 'NCEA Search Service Home',
   date: 'NCEA Guided Search - Study Period',
-  geography: 'NCEA Guided Search -Geographic Data',
+  geography: 'NCEA Guided Search - Geographic Data',
   results: 'NCEA Search Results Summary',
   generalTab: 'NCEA Catalogue Detail - General',
   accessTab: 'NCEA Catalogue Detail - Access',
@@ -270,4 +271,5 @@ export const pageTitles = {
   geographyTab: 'NCEA Catalogue Detail - Geography',
   governanceTab: 'NCEA Catalogue Detail - Governance',
   licenseTab: 'NCEA Catalogue Detail - License',
+  accessibility: 'Accessibility statement',
 };

--- a/src/views/layout/default.njk
+++ b/src/views/layout/default.njk
@@ -107,8 +107,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
           text: "Cookies"
         },
         {
-          href: "#",
+          href: routes.accessibilityStatement,
           text: "Accessibility statement"
+        },
+        {
+          href: "#",
+          text: "Terms and conditions"
         }
       ]
     }

--- a/src/views/partials/go_to_resource/template.njk
+++ b/src/views/partials/go_to_resource/template.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% if params.isDetailsPage %}
-  {% set buttonClasses = 'govuk-!-margin-bottom-4' %}
+  {% set buttonClasses = 'govuk-!-margin-bottom-4 ' %}
 {% else %}
   {% set buttonClasses = 'govuk-!-margin-bottom-0' %}
 {% endif %}
@@ -15,4 +15,4 @@
   {% set openDataAttributes = openDataAttributes | merge({disabled: "true"}) %}
 {% endif %}
 
-{{ govukButton({ text: 'Go to resource', attributes: openDataAttributes, classes: buttonClasses }) }}
+{{ govukButton({ text: 'Go to resource', attributes: openDataAttributes, classes: buttonClasses, isStartButton: params.isDetailsPage }) }}

--- a/src/views/screens/home/accessibility.njk
+++ b/src/views/screens/home/accessibility.njk
@@ -1,0 +1,51 @@
+{% extends "layout/default.njk" %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+{% block beforeContent %}
+  {{ super() }}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: routes.homePage,
+        attributes: {
+          'data-do-storage-reset': ''
+        }
+      },
+      {
+        text: "Accessibility statement"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <article class="govuk-grid-row" role="article">
+    <article class="govuk-grid-column-full ncea-static-page">
+      <h1 class="govuk-heading-m ncea-static-page__heading-m">Accessibility statement</h1>
+      <section class="ncea-static-page__content">
+        <p class="ncea-static-page__content-item">This accessibility statement applies to the Natural Capital Search Service.</p>
+        <p class="ncea-static-page__content-item">This service is run by the NCEA programme, on behalf of the Department for Environment, Food and Rural Affairs (Defra).</p>
+        <p class="ncea-static-page__content-item">We want as many people as possible to be able to use this website. It has been designed using GDS components and patterns, which are accessible. We've also made the website text as simple as possible to understand.</p>
+      </section>
+      <h2 class="govuk-heading-s ncea-static-page__heading-s govuk-!-margin-top-4">What we're doing to improve accessibility</h2>
+      <section class="ncea-static-page__content">
+        <p class="ncea-static-page__content-item">This service is currently in private beta. It does not yet fully meet <a href="https://www.w3.org/WAI/standards-guidelines/wcag/" class="govuk-link" target="_blank">Web Content Accessibility Guidelines</a> version 2.2 AA standard.</p>
+        <p class="ncea-static-page__content-item">An accessibility audit will take place during private beta. After the audit, we will work alongside other government departments and agencies to fix content which fails to meet the Web Content Accessibility Guidelines version 2.2 AA standard.</p>
+        <p class="ncea-static-page__content-item">An updated accessibility statement will be published after this date.</p>
+      </section>
+      <h2 class="govuk-heading-s ncea-static-page__heading-s govuk-!-margin-top-4">Feedback and contact information</h2>
+      <section class="ncea-static-page__content">
+        <p class="ncea-static-page__content-item">
+          If you would like to give feedback or report accessibility problems with this service, email us at <a class="govuk-link" href="mailto:NCEAemail@email.com">NCEAemail@email.com.</a>
+        </p>
+      </section>
+      <h2 class="govuk-heading-s ncea-static-page__heading-s govuk-!-margin-top-4">Preparation of this accessibility statement</h2>
+      <section class="ncea-static-page__content govuk-!-margin-bottom-8">
+        <p class="ncea-static-page__content-item">This statement was prepared on 26 April 2024.</p>
+        <p class="ncea-static-page__content-item">Last updated 29 April 2024.</p>
+      </section>
+    </article>
+  </article>
+{% endblock %}


### PR DESCRIPTION
### What one thing this PR does?

This will create a new page that displays the content of the accessibility statement, which can be accessed through the footer links.

### Task details

- [373333 - [Footer] Accessibility  statement content](https://dev.azure.com/defragovuk/DEFRA-NCEA/_workitems/edit/373333/)

### Other notes

- The content is all static and has been hardcoded in the nunjucks template.

### How do these changes look like?

**Accessibility statement content**
| ![Accessibility statement content](https://github.com/DEFRA/ncea-frontend/assets/131792244/81c1d75e-190a-4c6d-8d55-52fa7d76401a) |
| ------------------------------ |

### Dev-tested in

1. Local environment

- [Accessibility statement](http://localhost:3000/accessibility-statement)

2. Dev environment

- [Accessibility statement](https://dev-ncea-search.azure.defra.cloud/accessibility-statement)
