### PR TITLE
387101 - Fixing the multiple study period UI fix.

### DIFF
--- a/__tests__/utils/formatSearchResponse.spec.ts
+++ b/__tests__/utils/formatSearchResponse.spec.ts
@@ -608,7 +608,7 @@ describe('Format the search response', () => {
         { start: { date: '2022-02-01' }, end: { date: '2022-02-28' } },
       ];
       expect(getStudyPeriodDetails(true, dateRanges)).toBe(
-        '1 January 2022 to 31 January 2022\n1 February 2022 to 28 February 2022',
+        '1 January 2022 to 31 January 2022<br>1 February 2022 to 28 February 2022',
       );
     });
     test('handles missing start date', () => {

--- a/src/utils/formatSearchResponse.ts
+++ b/src/utils/formatSearchResponse.ts
@@ -52,7 +52,7 @@ export const getStudyPeriodDetails = (isDetails: boolean, dateRanges: IDateRange
     }
   }
 
-  return resultString.join('\n');
+  return resultString.join('<br>');
 };
 
 const formatSearchResponse = async (


### PR DESCRIPTION
### What one thing this PR does?

The UI fix that concerns the multiple study period values will be fixed by this

### Task details

- [387101 - GeneralTab_Multiple Study Periods are not displayed in search results page](https://dev.azure.com/defragovuk/DEFRA-NCEA/_workitems/edit/387101/)

### Other notes

N/A

### How do these changes look like?

**Multiple study period**
| ![Multiple study period](https://github.com/DEFRA/ncea-frontend/assets/131792244/36eb51d5-89cf-4887-8417-47c8cdf16513) |
| ------------------------------ |

### Dev-tested in

1. Local environment

- [Details page](http://localhost:3000/search/85fcb055-37e7-49bb-b235-d6c9eef548f9e?q=extraction&jry=qs&pg=1&rpp=20&srt=best_match#general)

2. Dev environment

- [Details page](https://dev-ncea-geonetwork.azure.defra.cloud/search/85fcb055-37e7-49bb-b235-d6c9eef548f9e?q=extraction&jry=qs&pg=1&rpp=20&srt=best_match#general)
