### PR TITLE
Set helm override for min autoscale replicas

### DIFF
--- a/ncea-fe/values/values.yaml
+++ b/ncea-fe/values/values.yaml
@@ -51,7 +51,7 @@ resources:
 
 autoscaling:
   enabled: $(autoScalingEnabled)
-  minReplicas: 1
+  minReplicas: $(autoScalingMinReplicas)
   maxReplicas: $(autoScalingMaxReplicas)
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80

--- a/pipeline/steps-deploy-helm-charts.yaml
+++ b/pipeline/steps-deploy-helm-charts.yaml
@@ -55,6 +55,7 @@ steps:
         ingress.hosts[0].host=$(hostName)
         autoscaling.enabled=$(autoScalingEnabled)
         autoscaling.maxReplicas=$(autoScalingMaxReplicas)
+        autoscaling.minReplicas=$(autoScalingMinReplicas)
         env.PORT=$(port)
         env.NODE_ENV=$(nodeEnv)
         env.AZURE_KEYVAULT_URL=$(keyVaultUri)


### PR DESCRIPTION
### What one thing this PR does?

1. Add autoScalingMinReplicas to helm deployment and values to allow us to control the minimum number of instances in the ADO variable groups. I have set to 2
2. Autoscale has been enabled in the variable groups

### Task details

Enable autoscale and set min number of replicas

### Other notes

This can easily be reverted by setting the following values in the variable group:
autoScalingEnabled = false
autoScalingMinReplicas = 1

### How do these changes look like?


### Dev-tested in

1. Local environment

NA

3. Dev environment

NA
