### PR TITLE
Commented count from resource type and updated classifier query

### DIFF
--- a/__tests__/utils/formatAggregationResponse.spec.ts
+++ b/__tests__/utils/formatAggregationResponse.spec.ts
@@ -40,41 +40,41 @@ describe('formatAggregationResponse', () => {
       aggregations: {
         category: {
           buckets: [
-            { key: 'nonGeographicDataset', doc_count: 5 },
-            { key: 'publication', doc_count: 10 },
+            { key: 'nonGeographicDataset' },
+            { key: 'publication' },
           ],
         },
       },
     };
   const filterOptions = [{ key: 'category', isTerm: true, propertyToRead: 'key', needCount: true }];
     const result = await formatAggregationResponse(apiResponse, filterOptions);
-    expect(result.category).toEqual([{ value: 'nonGeographicDataset', text: 'Non Geographic Dataset (15)' }]);
+    expect(result.category).toEqual([{ value: 'nonGeographicDataset', text: 'Non Geographic Dataset' }]);
   });
 
   it('should rename the publication bucket to nonGeographicDataset when only publication is present', async () => {
     const apiResponse = {
       aggregations: {
         category: {
-          buckets: [{ key: 'publication', doc_count: 10 }],
+          buckets: [{ key: 'publication'}],
         },
       },
     };
     const filterOptions = [{ key: 'category', isTerm: true, propertyToRead: 'key', needCount: true }];
     const result = await formatAggregationResponse(apiResponse, filterOptions);
-    expect(result.category).toEqual([{ value: 'nonGeographicDataset', text: 'Non Geographic Dataset (10)' }]);
+    expect(result.category).toEqual([{ value: 'nonGeographicDataset', text: 'Non Geographic Dataset' }]);
   });
 
   it('should not modify buckets if neither nonGeographicDataset nor publication are present', async () => {
     const apiResponse = {
       aggregations: {
         category: {
-          buckets: [{ key: 'otherDataset', doc_count: 10 }],
+          buckets: [{ key: 'otherDataset' }],
         },
       },
     };
     const filterOptions = [{ key: 'category', isTerm: true, propertyToRead: 'key', needCount: true }];
     const result = await formatAggregationResponse(apiResponse, filterOptions);
-    expect(result.category).toEqual([{ value: 'otherDataset', text: 'Other Dataset (10)' }]);
+    expect(result.category).toEqual([{ value: 'otherDataset', text: 'Other Dataset' }]);
   });
 
   it('should return formatted aggregation options for each filter option', async () => {
@@ -82,14 +82,14 @@ describe('formatAggregationResponse', () => {
       aggregations: {
         category: {
           buckets: [
-            { key: 'electronics', doc_count: 10 },
-            { key: 'clothing', doc_count: 20 },
+            { key: 'electronics' },
+            { key: 'clothing' },
           ],
         },
         brand: {
           buckets: [
-            { key_as_string: 'samsung', doc_count: 5 },
-            { key_as_string: 'apple', doc_count: 15 },
+            { key_as_string: 'samsung' },
+            { key_as_string: 'apple' },
           ],
         },
       },
@@ -117,8 +117,8 @@ describe('formatAggregationResponse', () => {
 
     const expectedResponse: IAggregationOptions = {
       category: [
-        { value: 'electronics', text: 'Electronics (10)' },
-        { value: 'clothing', text: 'Clothing (20)' },
+        { value: 'electronics', text: 'Electronics' },
+        { value: 'clothing', text: 'Clothing' },
       ],
       brand: [
         { value: 'samsung', text: 'Samsung' },

--- a/__tests__/utils/queryBuilder.spec.ts
+++ b/__tests__/utils/queryBuilder.spec.ts
@@ -2129,7 +2129,7 @@ describe('Build the search query', () => {
           },
         },
         sort: 'most_relevant',
-        filters: { [resourceTypeFilterField]: ['all'] },
+        filters: { [resourceTypeFilterField]: ['all'], parent: ['lvl1-001'], },
         rowsPerPage: 20,
         page: 1,
       };
@@ -2177,7 +2177,7 @@ describe('Build the search query', () => {
           },
         },
         sort: 'most_relevant',
-        filters: { [resourceTypeFilterField]: ['dataset'] },
+        filters: { [resourceTypeFilterField]: ['dataset'],  parent: ['lvl1-001'], },
         rowsPerPage: 20,
         page: 1,
       };
@@ -2227,7 +2227,7 @@ describe('Build the search query', () => {
           },
         },
         sort: 'most_relevant',
-        filters: { [resourceTypeFilterField]: ['dataset', 'series'] },
+        filters: { [resourceTypeFilterField]: ['dataset', 'series'],  parent: ['lvl1-001'], },
         rowsPerPage: 20,
         page: 1,
       };
@@ -3592,7 +3592,7 @@ describe('Build the search query', () => {
           },
         },
         sort: 'most_relevant',
-        filters: { [resourceTypeFilterField]: ['dataset', 'series'] },
+        filters: { [resourceTypeFilterField]: ['dataset', 'series'],  parent: ['lvl1-001'], },
         rowsPerPage: 20,
         page: 1,
       };
@@ -3652,7 +3652,7 @@ describe('Build the search query', () => {
           },
         },
         sort: 'most_relevant',
-        filters: { [resourceTypeFilterField]: ['dataset', 'series'] },
+        filters: { [resourceTypeFilterField]: ['dataset', 'series'], parent: ['lvl1-001'], },
         rowsPerPage: 20,
         page: 1,
       };
@@ -3817,7 +3817,7 @@ describe('Build the search query', () => {
           },
         },
         sort: 'most_relevant',
-        filters: { [resourceTypeFilterField]: ['dataset', 'series'] },
+        filters: { [resourceTypeFilterField]: ['dataset', 'series'], parent: ['lvl1-001'], },
         rowsPerPage: 20,
         page: 1,
       };

--- a/__tests__/utils/queryBuilder.spec.ts
+++ b/__tests__/utils/queryBuilder.spec.ts
@@ -218,6 +218,31 @@ describe('Build the search query', () => {
       expect(result.query?.bool?.filter).toHaveLength(2);
     });
 
+    it('should generate a query with default isStudyPeriod (false)', () => {
+      const searchFieldsObject: ISearchPayload = {
+        fields: {
+          classify: {
+            level: '2',
+            parent: ['lv2-009'],
+          },
+        },
+        filters: {},
+        sort: '',
+        rowsPerPage: 10,
+        page: 1,
+      };
+
+      const searchBuilderPayload: ISearchBuilderPayload = {
+        searchFieldsObject,
+        isCount: false,
+        isAggregation: false,
+      };
+
+      const result = generateFilterQuery(searchBuilderPayload, {});
+
+      expect(result.query?.bool?.filter).toBeDefined();
+     });
+
     it('should build the search query correctly with only search term', () => {
       const searchFieldsObject: ISearchPayload = {
         fields: {

--- a/__tests__/utils/queryBuilder.spec.ts
+++ b/__tests__/utils/queryBuilder.spec.ts
@@ -8,6 +8,8 @@ import {
   buildCustomSortScriptForStudyPeriod,
   generateFilterQuery,
   generateSearchQuery,
+  generateQueryStringBlock,
+  generateQuery,
 } from '../../src/utils/queryBuilder';
 
 const oldestStudySortScript = buildCustomSortScriptForStudyPeriod('asc');
@@ -15,6 +17,44 @@ const newestStudySortScript = buildCustomSortScriptForStudyPeriod('desc');
 
 describe('Build the search query', () => {
   describe('Search query without sort', () => {
+
+    it('should generate a query string block without fieldsToSearch (default to empty array)', () => {
+      const searchTerm = 'testSearchTerm';
+
+      const result = generateQueryStringBlock(searchTerm);
+
+      expect(result).toEqual({
+        query_string: {
+          query: 'testSearchTerm',
+          default_operator: 'AND',
+        },
+      });
+    });
+
+    it('should generate a query without fieldsToSearch (default to empty array)', () => {
+      const searchFieldsObject: ISearchPayload = {
+        fields: {
+          classify: {
+            level: '1',
+            parent: ['parent1'],
+          },
+        },
+        sort: '',
+        filters: {},
+        rowsPerPage: 20,
+        page: 1,
+      };
+
+      const searchBuilderPayload: ISearchBuilderPayload = {
+        searchFieldsObject,
+        docId: '',
+      };
+
+      const result = generateQuery(searchBuilderPayload);
+
+      expect(result.query?.bool?.must).toBeUndefined();
+    });
+
     it('should build the search query correctly with date range and when fields are not provided', () => {
       const searchFieldsObject: ISearchPayload = {
         fields: {

--- a/__tests__/utils/queryBuilder.spec.ts
+++ b/__tests__/utils/queryBuilder.spec.ts
@@ -2994,6 +2994,31 @@ describe('Build the search query', () => {
       expect(termsBlock.terms['OrgNceaClassifiers.classifiers.code.keyword']).toEqual([]);
     }
   });
+
+  it('should return an empty array if parent is not provided', () => {
+    const parent = undefined;
+    const parentArray = typeof parent === 'string' ? (parent as string).split(',').map((item) => item.trim()) : [];
+    expect(parentArray).toEqual([]);
+  });
+
+  it('should return an empty array if parent is an empty string', () => {
+    const parent = '';
+    const parentArray = typeof parent === 'string' ? (parent as string).split(',').map((item) => item.trim()) : [];
+    expect(parentArray).toEqual(['']);
+  });
+
+  it('should split the parent string by comma and trim each item', () => {
+    const parent = 'lv3-020, lv3-021 ,lv3-022';
+    const parentArray = typeof parent === 'string' ? (parent as string).split(',').map((item) => item.trim()) : [];
+    expect(parentArray).toEqual(['lv3-020', 'lv3-021', 'lv3-022']);
+  });
+
+  it('should return an empty array if parent is a non-string value', () => {
+    const parent = 12345;
+    const parentArray = typeof parent === 'string' ? (parent as string).split(',').map((item) => item.trim()) : [];
+    expect(parentArray).toEqual([]);
+  });
+
     it('should build the search query for resourceType aggregation with study period filter', () => {
       const searchFieldsObject: ISearchPayload = {
         fields: {

--- a/__tests__/utils/queryBuilder.spec.ts
+++ b/__tests__/utils/queryBuilder.spec.ts
@@ -2366,6 +2366,7 @@ describe('Build the search query', () => {
             fdy: '2017',
             tdy: '2022',
           },
+          parent: ['lvl1-001'],
         },
         rowsPerPage: 20,
         page: 1,
@@ -3120,6 +3121,7 @@ describe('Build the search query', () => {
             fdy: '2017',
             tdy: '2022',
           },
+
         },
         rowsPerPage: 20,
         page: 1,
@@ -3921,6 +3923,7 @@ describe('Build the search query', () => {
             fdy: '2017',
             tdy: '2022',
           },
+          parent: ['lvl1-001'],
         },
         rowsPerPage: 20,
         page: 1,

--- a/__tests__/utils/queryBuilder.spec.ts
+++ b/__tests__/utils/queryBuilder.spec.ts
@@ -2129,7 +2129,7 @@ describe('Build the search query', () => {
           },
         },
         sort: 'most_relevant',
-        filters: { [resourceTypeFilterField]: ['all'], parent: ['lvl1-001'], },
+        filters: { [resourceTypeFilterField]: ['all'] },
         rowsPerPage: 20,
         page: 1,
       };
@@ -2352,7 +2352,7 @@ describe('Build the search query', () => {
       expect(result.query?.bool?.filter).toHaveLength(1);
     });
 
-    it('should build the search query when filtering with both resourceType and study period', () => {
+    it('should build the search query when filtering with both resourceType , study period and classifier', () => {
       const searchFieldsObject: ISearchPayload = {
         fields: {
           keyword: {

--- a/src/utils/formatAggregationResponse.ts
+++ b/src/utils/formatAggregationResponse.ts
@@ -57,8 +57,9 @@ const formatAggregationResponse = async (
         }
         finalResponse[filterOption.key] = apiAggValues?.buckets.map((bucket) => {
           const wordsWithSpace = addSpaces(bucket[filterOption.propertyToRead]);
-          let text: string = capitalizeWords(wordsWithSpace);
-          if (filterOption.needCount) text += ` (${bucket['doc_count']})`;
+          const text: string = capitalizeWords(wordsWithSpace);
+          //commented the count part for resource tyoe
+          // if (filterOption.needCount) text += ` (${bucket['doc_count']})`;
           return {
             value: bucket[filterOption.propertyToRead],
             text,

--- a/src/utils/queryBuilder.ts
+++ b/src/utils/queryBuilder.ts
@@ -10,7 +10,7 @@ import {
 } from '../interfaces/queryBuilder.interface';
 import { levelMap, mapResultMaxCount, resourceTypeFilterField, studyPeriodFilterField } from './constants';
 
-const _generateQueryStringBlock = (
+const generateQueryStringBlock = (
   searchTerm: string,
   fieldsToSearch: string[] = [],
 ): estypes.QueryDslQueryContainer => {
@@ -161,14 +161,14 @@ const _generateOtherQueryProperties = (searchBuilderPayload: ISearchBuilderPaylo
   } as estypes.SearchRequest;
 };
 
-const _generateQuery = (searchBuilderPayload: ISearchBuilderPayload): estypes.SearchRequest => {
+const generateQuery = (searchBuilderPayload: ISearchBuilderPayload): estypes.SearchRequest => {
   const { searchFieldsObject, fieldsToSearch = [], docId = '' } = searchBuilderPayload;
   const { fields, fieldsExist = [] } = (searchFieldsObject as ISearchPayload) ?? {};
 
   const searchTerm: string = fields?.keyword?.q as string;
 
-  const mustBlock: estypes.QueryDslQueryContainer[] = docId ? [_generateQueryStringBlock(docId, ['_id'])] : [];
-  if (searchTerm && docId === '') mustBlock.push(_generateQueryStringBlock(searchTerm, fieldsToSearch));
+  const mustBlock: estypes.QueryDslQueryContainer[] = docId ? [generateQueryStringBlock(docId, ['_id'])] : [];
+  if (searchTerm && docId === '') mustBlock.push(generateQueryStringBlock(searchTerm, fieldsToSearch));
   if (fieldsExist.length > 0 && docId === '') {
     fieldsExist.forEach((field: string) => {
       mustBlock.push(_generateFieldExistsBlock(field));
@@ -219,7 +219,7 @@ const _generateDateRangeQuery = (
 };
 
 const generateSearchQuery = (searchBuilderPayload: ISearchBuilderPayload): estypes.SearchRequest => {
-  const queryPayload: estypes.SearchRequest = _generateQuery(searchBuilderPayload);
+  const queryPayload: estypes.SearchRequest = generateQuery(searchBuilderPayload);
   const { searchFieldsObject, docId = '' } = searchBuilderPayload;
   const { filters } = (searchFieldsObject as ISearchPayload) ?? {};
   if (docId === '') {
@@ -243,7 +243,7 @@ const generateSearchQuery = (searchBuilderPayload: ISearchBuilderPayload): estyp
 };
 
 const _generateStudyPeriodFilterQuery = (searchBuilderPayload: ISearchBuilderPayload): estypes.SearchRequest => {
-  const queryPayload: estypes.SearchRequest = _generateQuery(searchBuilderPayload);
+  const queryPayload: estypes.SearchRequest = generateQuery(searchBuilderPayload);
   const { searchFieldsObject, docId = '' } = searchBuilderPayload;
   const { fields, filters } = searchFieldsObject as ISearchPayload;
   const { level, parent } = (searchFieldsObject?.fields.classify as ISearchPayload) ?? {};
@@ -289,7 +289,7 @@ const _generateStudyPeriodFilterQuery = (searchBuilderPayload: ISearchBuilderPay
 };
 
 const _generateResourceTypeFilterQuery = (searchBuilderPayload: ISearchBuilderPayload): estypes.SearchRequest => {
-  const queryPayload: estypes.SearchRequest = _generateQuery(searchBuilderPayload);
+  const queryPayload: estypes.SearchRequest = generateQuery(searchBuilderPayload);
   const { docId = '' } = searchBuilderPayload;
   if (docId === '') {
     const filterBlock: estypes.QueryDslQueryContainer[] = _generateDateRangeQuery(searchBuilderPayload, queryPayload);
@@ -319,4 +319,4 @@ const generateFilterQuery = (
     : _generateResourceTypeFilterQuery(searchBuilderPayload);
 };
 
-export { generateSearchQuery, generateFilterQuery, buildCustomSortScriptForStudyPeriod };
+export { generateQuery,generateQueryStringBlock,generateSearchQuery, generateFilterQuery, buildCustomSortScriptForStudyPeriod };

--- a/src/utils/queryBuilder.ts
+++ b/src/utils/queryBuilder.ts
@@ -199,6 +199,7 @@ const _generateDateRangeQuery = (
   const { filters, fields } = (searchFieldsObject as ISearchPayload) ?? {};
   const { level, parent } = (searchFieldsObject?.fields.classify as ISearchPayload) ?? {};
   const parentArray = typeof parent === 'string' ? (parent as string).split(',').map((item) => item.trim()) : [];
+  const newParentArray = [...new Set(parentArray)];
   const filterBlock: estypes.QueryDslQueryContainer[] =
     (queryPayload.query?.bool?.filter as estypes.QueryDslQueryContainer[]) ?? [];
   const studyPeriodFilter: IDateValues = (filters?.[studyPeriodFilterField] as IDateValues) ?? { fdy: '', tdy: '' };
@@ -212,7 +213,7 @@ const _generateDateRangeQuery = (
     filterBlock.push(..._generateRangeBlock(fields.date));
   }
   if (fields?.classify?.level && fields.classify.parent) {
-    filterBlock.push(_generateTermsBlock(level && levelMap[level], parentArray));
+    filterBlock.push(_generateTermsBlock(level && levelMap[level], newParentArray));
   }
   return filterBlock;
 };
@@ -248,6 +249,7 @@ const _generateStudyPeriodFilterQuery = (searchBuilderPayload: ISearchBuilderPay
   const { level, parent } = (searchFieldsObject?.fields.classify as ISearchPayload) ?? {};
 
   const parentArray = typeof parent === 'string' ? (parent as string).split(',').map((item) => item.trim()) : [];
+  const newParentArray = [...new Set(parentArray)];
   if (docId === '') {
     const mustBlock: estypes.QueryDslQueryContainer[] =
       (queryPayload.query?.bool?.must as estypes.QueryDslQueryContainer[]) ?? [];
@@ -261,7 +263,7 @@ const _generateStudyPeriodFilterQuery = (searchBuilderPayload: ISearchBuilderPay
       mustBlock.push(_generateTermsBlock('resourceType', filters[resourceTypeFilterField] as string[]));
     }
     if (level && levelMap[level]) {
-      filterBlock.push(_generateTermsBlock(levelMap[level], parentArray));
+      filterBlock.push(_generateTermsBlock(levelMap[level], newParentArray));
     }
     if (queryPayload?.query?.bool) {
       queryPayload.query.bool = {


### PR DESCRIPTION
### What one thing this PR does?

Hide the count from resource type and updated classifier query

### Task details

- [Activity ID - Task title/short description](activity_url)

### Other notes

- Additional details about the task
- Important points that other teams or reviewers should be aware of.

### How do these changes look like?

| ![name of the screengrab](URL) |
<img width="1342" alt="Screenshot 2024-09-30 at 11 41 45" src="https://github.com/user-attachments/assets/1bc47bd7-5139-4d31-b5cf-8dd340987979">
<img width="1345" alt="Screenshot 2024-09-30 at 14 31 57" src="https://github.com/user-attachments/assets/6d97c9c7-07ed-459f-9c6b-9d69d841956f">



### Dev-tested in

1. Local environment

- [Page name/link 1](http://localhost:3000/search?q=chemistry&jry=qs&pg=1&rpp=20&srt=most_relevant&rty=series)
- [Page name/link 2](url)

2. Dev environment

- [Page name/link 1](url)
- ...
